### PR TITLE
Add interfaceImplementer function

### DIFF
--- a/Sources/web3swift/Utils/ENS/ENSResolver.swift
+++ b/Sources/web3swift/Utils/ENS/ENSResolver.swift
@@ -19,7 +19,7 @@ public extension ENS {
             case CBOR = 4
             case URI = 8
         }
-        
+
         public enum InterfaceName {
             case addr
             case name
@@ -71,6 +71,14 @@ public extension ENS {
             guard let result = try? transaction.call(transactionOptions: defaultOptions) else {throw Web3Error.processingError(desc: "Can't call transaction")}
             guard let supports = result["0"] as? Bool else {throw Web3Error.processingError(desc: "Can't get answer")}
             return supports
+        }
+
+        public func interfaceImplementer(forNode node: String, interfaceID: InterfaceID) throws -> EthereumAddress {
+            guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
+            guard let transaction = self.resolverContract.read("interfaceImplementer", parameters: [nameHash, interfaceID] as [AnyObject], extraData: Data(), transactionOptions: defaultOptions) else {throw Web3Error.transactionSerializationError}
+            guard let result = try? transaction.call(transactionOptions: defaultOptions) else {throw Web3Error.processingError(desc: "Can't call transaction")}
+            guard let address = result["0"] as? EthereumAddress else {throw Web3Error.processingError(desc: "Can't get address")}
+            return address
         }
         
         public func getAddress(forNode node: String) throws -> EthereumAddress {


### PR DESCRIPTION
Added `interfaceImplementer` function found in the new [OwnedResolver](https://ropsten.etherscan.io/address/0x44385b20865fe3578e56aa0e9f7ec534deb10501#code).

### Usage

```swift
public enum InterfaceID: String {
    case legacyRegistrar = "0x7ba18ba1"
    case permanentRegistrar = "0x018fac06"
    case baseRegistrar = "0x6ccb2df4"
}

// Get the ETHRegistrarController's address
let controller = try! e.resolver?.interfaceImplementer(forNode: "eth", interfaceID: InterfaceID.permanentRegistrar.rawValue)
```

See more usage at: https://github.com/ensdomains/ens-app/blob/d79a4f5a8231e46743caa19d0368fff9fe237383/src/api/registrar.js#L94